### PR TITLE
Allow user to specify they do not want to encode the service parameter

### DIFF
--- a/src/AspNetCore.Security.CAS/CasHandler.cs
+++ b/src/AspNetCore.Security.CAS/CasHandler.cs
@@ -52,7 +52,7 @@ namespace AspNetCore.Security.CAS
                 return HandleRequestResult.Fail("Missing CAS ticket.");
             }
 
-            var casService = Uri.EscapeDataString(BuildReturnTo(state));
+            var casService = Options.EscapeServiceString ? Uri.EscapeDataString(BuildReturnTo(state)) : BuildReturnTo(state);
             var authTicket = await Options.TicketValidator.ValidateTicket(Context, properties, Scheme, Options, casTicket, casService);
             if (authTicket == null)
             {
@@ -73,7 +73,11 @@ namespace AspNetCore.Security.CAS
             GenerateCorrelationId(properties);
 
             var returnTo = BuildReturnTo(Options.StateDataFormat.Protect(properties));
-            var authorizationEndpoint = $"{Options.CasServerUrlBase}/login?service={Uri.EscapeDataString(returnTo)}";
+            if (Options.EscapeServiceString)
+            {
+                returnTo = Uri.EscapeDataString(returnTo);
+            }
+            var authorizationEndpoint = $"{Options.CasServerUrlBase}/login?service={returnTo}";
 
             if (Options.Renew)
             {

--- a/src/AspNetCore.Security.CAS/CasOptions.cs
+++ b/src/AspNetCore.Security.CAS/CasOptions.cs
@@ -95,6 +95,15 @@ namespace Microsoft.AspNetCore.Builder
         public bool ServiceForceHTTPS { get; set; } = false;
 
         /// <summary>
+        /// Escape the the service parameter string when sending requests to the CAS server
+        /// <para />
+        /// The default behavior to build the `service uri` is to escape, however, not all CAS
+        /// server implementations will decode this value on receiving it.
+        /// </summary>
+        /// <example>false</example>
+        public bool EscapeServiceString { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the <see cref="CasEvents"/> used to handle authentication events.
         /// </summary>
         public new CasEvents Events


### PR DESCRIPTION
Not all CAS servers decode the service string when it arrives.
This means some requests will be rejected because the service parameter does not match the address on the CAS server.
This should allow for disabling encoding of the service uri.